### PR TITLE
nav to individual easier

### DIFF
--- a/content/general/individual.md
+++ b/content/general/individual.md
@@ -1,0 +1,14 @@
+title: Individual
+date: 2024-03-20
+tags: assignment, grading
+authors: Hazel Victoria Campbell, Sarah Nadi, Neel Patel
+status: published
+summary: Individual Assignments
+----
+
+# Assignments
+
+* [Individual Assignment 1: Testing Theory]({filename}/individual/testing-theory.md)
+* [Individual Assignment 2: Testing with Mocks]({filename}/individual/testing-mocks.md)
+* [Individual Assignment 3: Performance Assessment]({filename}/individual/performance-assessment.md)
+* **Graduate students 501 only** [Research Presentations]({filename}/individual/research-presentation.md)

--- a/content/general/project.md
+++ b/content/general/project.md
@@ -1,4 +1,4 @@
-title: Project
+title: Group Project
 date: 2024-01-06
 tags: project, grading
 authors: Hazel Victoria Campbell, Sarah Nadi

--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -13,13 +13,6 @@ save_as: index.html
 * [Course Schedule]({filename}/general/schedule.md)
 * [Reference Material, eBooks, & Resources]({filename}/general/resources.md)
 
-# Assignments
-
-* [Individual Assignment 1: Testing Theory]({filename}/individual/testing-theory.md)
-* [Individual Assignment 2: Testing with Mocks]({filename}/individual/testing-mocks.md)
-* [Individual Assignment 3: Performance Assessment]({filename}/individual/performance-assessment.md)
-* **Graduate students 501 only** [Research Presentations]({filename}/individual/research-presentation.md)
-
 
 # Lecture Material
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -73,6 +73,7 @@ MENUITEMS=[
     ("Schedule", "/general/schedule.html"),
     ("Labs", "/general/labs.html"),
     ("Project", "/general/project.html"),
+    ("Individual", "/general/individual.html"),
     ("Resources", "/general/resources.html"),
     ("Help", "/general/help.html"),
 ]


### PR DESCRIPTION
Made navigation to individual assignments easier; initially, it wasn't obvious where the individual assignments were unless it was through eClass.

Added an item to the menu to take to the page where the assignments are.
Removed assignment info from the main page.
Retitle "Project" to "Group Project"