### PR TITLE
Update copyright footer on homepage

### DIFF
--- a/templates/cmput402/templates/page.html
+++ b/templates/cmput402/templates/page.html
@@ -7,7 +7,7 @@
     <address>
         Copyright © 
         <ul>
-          <li>Dr. Hazel Campbell, Department of Computing Science, Faculty of Science, University of Alberta (2019, 2023, 2024).</li>
+          <li>Dr. Hazel Campbell, Department of Computing Science, Faculty of Science, University of Alberta (2019, 2023, 2024, 2025, 2026).</li>
           <li>Dr. Sarah Nadi, Department of Computing Science, Faculty of Science, University of Alberta (2022).</li>
           <li>Dr. Abram Hindle, Department of Computing Science, Faculty of Science, University of Alberta (2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023).</li>
           <li>Alexander Wong, 2019.</li>


### PR DESCRIPTION
New years (2025, 2026) added to the footer for copyright.
<img width="855" height="85" alt="Screenshot 2026-04-07 at 11 46 22 PM" src="https://github.com/user-attachments/assets/a1ae4d4d-96ce-4e79-8b7a-0b5589b1e8e9" />

Name: Mansoor Anis
CCID: manis