### PR TITLE
fix broken anchor link to TAs and Office Hour section

### DIFF
--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -11,7 +11,7 @@ save_as: index.html
     * [Wellness Supports]({filename}/general/help.md#wellness-supports)
 * [Course Schedule](#schedule)
 * [Reference Material, eBooks, & Resources]({filename}/general/resources.md)
-* [TAs & Office Hours]({filename}/general/help.md#tas)
+* [TAs & Office Hours]({filename}/general/help.md#tas-office-hours)
 * [Discussion & Announcements]({filename}/general/help.md#discussion-forum)
 
 # Schedule 


### PR DESCRIPTION
The link to TAs & Office Hour section in `home.md` pointed to `#tas` which does not match any of the headers since it was changed to `#tas-office-hours`.

- Updated the anchor to point to `#tas-office-hours` instead.

Name: Divy Vaghasiya
ccid: vaghasiy