### PR TITLE
Add assignment submission links page to navigation

### DIFF
--- a/content/general/submissions.md
+++ b/content/general/submissions.md
@@ -1,0 +1,28 @@
+title: Submission Links
+date: 2026-08-06
+tags: assignment, submission
+authors: Hooman Raffieipour
+status: published
+summary: Centralized assignment submission links
+
+----
+
+[TOC]
+
+# Group Assignments
+
+| Assignment | Submit | Peer Review |
+| --- | --- | --- |
+| [Group Assignment 1: Testing Basics]({filename}/group/basics.md) | [Google Form](G1_SUBMISSION_LINK) | [Peer Review](https://docs.google.com/forms/d/e/1FAIpQLSfBsjSVnjxEG07Fn_TYSMBNXr6Bxp41rt0VLebVMazLvHElQw/viewform?usp=publish-editor) |
+| [Group Assignment 2: Testing]({filename}/group/testing.md) | [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSf3VZlM5-7kVI-smNQpRDqzu9BGM_sjaWZyv6AgcfEFDrzORQ/viewform?usp=publish-editor) | [Peer Review](https://docs.google.com/forms/d/e/1FAIpQLScQ4elhFMPY3rvNkJD6kotSqBcYvHBMX5gYXJqXwCb4Iugr7Q/viewform?usp=publish-edito) |
+| [Group Assignment 3: Testing in Production]({filename}/group/testing-in-production.md) | [Google Form](https://docs.google.com/forms/d/e/1FAIpQLScLPSjl7HcbZFaxlp4ocEOlgvXLAjhujIh0HIlhRhqRwglt0g/viewform?usp=publish-editor) | [Peer Review](https://docs.google.com/forms/d/e/1FAIpQLScKKux1R6sTDrXZ_KqkaFCyd5m-iDuoBvKRp_OeIjXJcYdtrg/viewform?usp=publish-editor) |
+| [Group Assignment 4: Static Analysis]({filename}/group/static-analysis.md) | [Google Form](https://docs.google.com/forms/d/e/1FAIpQLScDsf2CIOIgM69wJU-yMTPnJKCL28jVnsy8fAJdt8gpcPoX5g/viewform?usp=publish-editor) | [Peer Review](https://docs.google.com/forms/d/e/1FAIpQLSdpDozQwfyaZOxusKKfMnpcNHfVVbH3Z5yTOMn-9tshktmEzg/viewform?usp=publish-editor) |
+| [Group Assignment 5: Technical Debt]({filename}/group/technical-debt.md) | [Google Form](G5_SUBMISSION_LINK) | [Peer Review](G5_PEER_REVIEW_LINK) |
+
+# Individual Assignments
+
+| Assignment | Submit |
+| --- | --- |
+| [Individual Assignment 1: Testing Theory]({filename}/individual/testing-theory.md) | [Google Form](I1_SUBMISSION_LINK) |
+| [Individual Assignment 2: Testing with Mocks]({filename}/individual/testing-mocks.md) | [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSd808gM37mpCgJmG0LpyCKuv05l4RwnkaLWRXLmjWt7NijRqg/viewform?usp=dialog) |
+| [Individual Assignment 3: Performance Assessment]({filename}/individual/performance-assessment.md) | [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSdyl_yo64kwMJykKXK-esU4lVwDpV75mkd-k0BP4VGE3VvgBA/viewform?usp=publish-editor) |

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -75,6 +75,7 @@ MENUITEMS=[
     ("Project", "/general/project.html"),
     ("Assignments", "/general/individual.html"),
     ("Resources", "/general/resources.html"),
+    ("Submissions", "/general/submissions.html"),
     ("Discussion Forum", "/general/help.html#discussion-forum"),
     ("News&Notices", "/#news-notices"),
     ("Zoom", "/#lecture-zoom"),


### PR DESCRIPTION
Adds a new Submissions page containing direct links to the submission forms for group and individual assignments.
